### PR TITLE
Remove stray character from responsive CSS block

### DIFF
--- a/style.css
+++ b/style.css
@@ -421,7 +421,6 @@ body {
 
 /* Responsive Adjustments */
 @media (max-width: 768px) {
-<
   .order-totals {
     flex-basis: auto;
   }


### PR DESCRIPTION
## Summary
- remove stray `<` from the `@media (max-width: 768px)` block in `style.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68537edbd65c832b849c21f8b4e9ca42