### PR TITLE
Add privacy and cookie policy pages

### DIFF
--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Information on how Modern Order App uses cookies.">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Cookie Policy - Modern Order App</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="policy-page">
+    <h1>Cookie Policy</h1>
+    <p>This placeholder page explains how we use cookies and similar technologies. Replace this text with your organisation's full cookie policy.</p>
+    <p><a href="index.html">Back to Home</a></p>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,14 @@
   </div>
 </div>
 
-<script src="script.js"></script>
+  <footer class="site-footer">
+    <p>
+      <a href="privacy-policy.html">Privacy Policy</a> |
+      <a href="cookie-policy.html">Cookie Policy</a>
+    </p>
+  </footer>
+
+  <script src="script.js"></script>
 
 <div id="cookieConsentBanner" style="display: none; position: fixed; bottom: 0; left: 0; right: 0; background: #333; color: white; padding: 15px; text-align: center; z-index: 1001;">
   <p style="margin: 0 0 10px 0;">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Learn how Modern Order App handles your data in our privacy policy.">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Privacy Policy - Modern Order App</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="policy-page">
+    <h1>Privacy Policy</h1>
+    <p>This placeholder page outlines how we handle your personal information. Replace this text with your organisation's full privacy policy.</p>
+    <p><a href="index.html">Back to Home</a></p>
+  </main>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,14 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>/privacy-policy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>/cookie-policy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/style.css
+++ b/style.css
@@ -473,3 +473,25 @@ body {
    .toggle-btn { padding: 0.3em 0.7em; font-size: 0.8rem;}
 
 }
+
+/* Footer and Policy Page Styles */
+.policy-page {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1rem;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 1rem 0;
+  font-size: 0.9rem;
+}
+
+.site-footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.site-footer a:hover {
+  text-decoration: underline;
+}

--- a/sw.js
+++ b/sw.js
@@ -7,6 +7,8 @@ const ASSETS_TO_CACHE = [
   '/style.css',
   '/manifest.json',
   '/offline.html',
+  '/privacy-policy.html',
+  '/cookie-policy.html',
   // Add placeholder icon paths if they were actual files, e.g.:
   // '/icons/icon-192x192.png',
   // '/icons/icon-512x512.png',


### PR DESCRIPTION
## Summary
- add `privacy-policy.html` and `cookie-policy.html`
- link policy pages in index footer
- style policy pages and footer
- include new pages in sitemap
- cache new pages via service worker

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685387d0364c832b99c4a52d5d86f200