### PR TITLE
Add Git LFS guidelines and binary tracking

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.mov filter=lfs diff=lfs merge=lfs -text
+*.avi filter=lfs diff=lfs merge=lfs -text
+*.mp3 filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.pdf filter=lfs diff=lfs merge=lfs -text
+

--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ These headers help reduce common web vulnerabilities when the app is deployed.
 - Review `manifest.json` to customise icons, name and theme colours for your brand.
 - Modify the list in `sw.js` if you add new files that should be cached for offline use.
 
+## Managing large files
+
+If you plan to store large assets such as images or videos in this repository,
+install [Git LFS](https://git-lfs.github.com/) before cloning or pushing. Git
+LFS stores binary data efficiently and prevents large files from bloating the
+repository. After installing, run `git lfs install` once, then commit files
+matching the patterns defined in `.gitattributes`.
+


### PR DESCRIPTION
## Summary
- track common binary formats with Git LFS
- document Git LFS setup in the README

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685387d477dc832b817f833c97baccfe