### PR TITLE
Add privacy and cookie policy pages

### DIFF
--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Cookie policy for the Order App" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://via.placeholder.com data:; style-src 'self' 'unsafe-inline'; script-src 'self';" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta http-equiv="X-Frame-Options" content="DENY" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>Cookie Policy</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main style="padding: 1rem; max-width: 800px; margin: auto;">
+    <h1>Cookie Policy</h1>
+    <p>This is placeholder text for the cookie policy. Replace this with information about how cookies are used on the site.</p>
+  </main>
+</body>
+</html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Privacy policy for the Order App" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://via.placeholder.com data:; style-src 'self' 'unsafe-inline'; script-src 'self';" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta http-equiv="X-Frame-Options" content="DENY" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>Privacy Policy</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main style="padding: 1rem; max-width: 800px; margin: auto;">
+    <h1>Privacy Policy</h1>
+    <p>This is placeholder text for the privacy policy. Update with your organisation's full policy details.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new placeholder pages `privacy-policy.html` and `cookie-policy.html`
- reference existing stylesheet and security meta tags

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685389a3083c832bb4ff7f0e2f54333a