### PR TITLE
Add placeholder PWA icons

### DIFF
--- a/icons/icon-192x192.png
+++ b/icons/icon-192x192.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32c97b90f9dba90468ff98d1ba804b2347a6dfdbd2e0004c1e866ee8aabdb283
+size 351

--- a/icons/icon-512x512.png
+++ b/icons/icon-512x512.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6d67497255a3c46d93614d2c8d152776b8aee8ad13c51f0a53b30ddc6dc161d
+size 1988


### PR DESCRIPTION
## Summary
- add 192x192 and 512x512 placeholder PNG icons for the PWA manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fb65d8c4832baceaceb35602ad69